### PR TITLE
fix missing location information when using the depth camera

### DIFF
--- a/aruco_pose_estimation/aruco_pose_estimation/pose_estimation.py
+++ b/aruco_pose_estimation/aruco_pose_estimation/pose_estimation.py
@@ -217,7 +217,7 @@ def depth_to_pointcloud_centroid(depth_image: np.array, intrinsic_matrix: np.arr
         pointcloud.append([x, y, z])
 
     # Calculate centroid from pointcloud
-    centroid = np.mean(np.array(pointcloud, dtype=np.uint16), axis=0)
+    centroid = np.mean(np.array(pointcloud, dtype=np.float32), axis=0)
 
     return centroid
 


### PR DESCRIPTION
# what's changed
* Changed to cast to appropriate type when calculating center of gravity for AR markers
* Specifically, from int16 to float32